### PR TITLE
fix: Always use cthreads on Linux

### DIFF
--- a/project1.lpr
+++ b/project1.lpr
@@ -3,9 +3,9 @@ program project1;
 {$mode objfpc}{$H+}
 
 uses
-  {$IFDEF UNIX}{$IFDEF UseCThreads}
+  {$IFDEF UNIX}
   cthreads,
-  {$ENDIF}{$ENDIF}
+  {$ENDIF}
   Classes, SysUtils,
   CodaMinaHashMap,CodaMinaPriorityQueue,
   CodaMinaTTree,CodaMinaBTree,CodaMinaBPlusTree,CodaMinaBStarTree,CodaMinaSkipList2


### PR DESCRIPTION
Hey Terry (@terrylao),

This makes it possible to compile `project1` under Linux without having to always set a flag to use `cthreads`.

Cheers,
Gus